### PR TITLE
feat: add worktree launcher helper scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,8 @@ yarn-debug.log*
 yarn-error.log*
 
 # Editor directories
-.vscode/
+.vscode/*
+!.vscode/settings.json  # Keep Peacock color settings for worktrees
 .idea/
 *.swp
 *.swo
@@ -194,3 +195,13 @@ logs/
 **/debug-output/
 scripts/cli-pipeline/**/debug-output/
 scripts/cli-pipeline/presentations/debug-output/
+
+# Raycast metadata (auto-generated)
+scripts/cli-pipeline/viewers/raycast-scripts/*.plist
+scripts/cli-pipeline/viewers/raycast-scripts/.DS_Store
+
+# User-specific worktree scripts are kept in git as templates
+# Users should update paths for their own setup
+# !scripts/cli-pipeline/viewers/raycast-scripts/*.sh
+# !scripts/cli-pipeline/viewers/setup-*.sh
+# !scripts/cli-pipeline/viewers/*-config.json

--- a/docs/macos-cursor-keyboard-shortcuts.md
+++ b/docs/macos-cursor-keyboard-shortcuts.md
@@ -1,0 +1,120 @@
+# macOS Keyboard Shortcuts for Cursor Worktrees
+
+## Quick Comparison of Methods
+
+| Method | Cost | Complexity | Features | Best For |
+|--------|------|------------|----------|----------|
+| **Automator + System Shortcuts** | Free | Medium | Basic but reliable | Built-in solution |
+| **Raycast** | Free | Easy | Fast, extensible | Power users |
+| **BetterTouchTool** | $22 | Easy | Most flexible | Custom gestures |
+| **Keyboard Maestro** | $36 | Medium | Most powerful | Complex automation |
+| **Hammerspoon** | Free | Hard | Scriptable | Developers |
+
+## Method 1: Native macOS (Automator + Shortcuts)
+
+### Setup Steps:
+1. Run the setup script:
+   ```bash
+   ./scripts/cli-pipeline/viewers/setup-worktree-shortcuts.sh
+   ```
+
+2. Open System Settings > Keyboard > Keyboard Shortcuts > App Shortcuts
+
+3. Click + and add shortcuts for each app:
+   - Application: "Cursor-1-Development"
+   - Menu Title: (leave blank)
+   - Keyboard Shortcut: ⌥1
+
+### Pros:
+- No third-party software needed
+- Works with macOS security features
+- Survives OS updates
+
+### Cons:
+- Requires creating 10 separate apps
+- Slightly more setup work
+
+## Method 2: Raycast (Recommended for Most Users)
+
+### Setup:
+1. Install Raycast (free): https://www.raycast.com
+2. Open Raycast Preferences
+3. Go to Extensions > Script Commands
+4. Add script for each worktree
+5. Assign hotkeys (⌥1 through ⌥0)
+
+### Pros:
+- Fast and responsive
+- Easy to modify
+- Can add additional features (window management, etc.)
+- Great UI
+
+### Cons:
+- Requires third-party app
+- Another app running in background
+
+## Method 3: BetterTouchTool
+
+### Setup:
+1. Install BetterTouchTool
+2. Add new keyboard shortcut
+3. Action: "Execute Terminal Command"
+4. Command: `/Applications/Cursor.app/Contents/MacOS/Cursor /path/to/worktree`
+
+### Pros:
+- Very flexible
+- Can combine with trackpad gestures
+- Window snapping features
+- TouchBar support
+
+### Cons:
+- Paid app ($22)
+- More complex interface
+
+## Method 4: Simple Shell Aliases (Terminal)
+
+Add to your `~/.zshrc`:
+
+```bash
+alias c1='cursor /Users/raybunnage/Documents/github/dhg-mono'
+alias c2='cursor /Users/raybunnage/Documents/github/dhg-mono-admin-code'
+alias c3='cursor /Users/raybunnage/Documents/github/dhg-mono-dhg-hub'
+alias c4='cursor /Users/raybunnage/Documents/github/dhg-mono-feature/dhg-mono-docs'
+alias c5='cursor /Users/raybunnage/Documents/github/dhg-mono-gmail-cli-pipeline-research-app'
+alias c6='cursor /Users/raybunnage/Documents/github/dhg-mono-improve-audio'
+alias c7='cursor /Users/raybunnage/Documents/github/dhg-mono-improve-cli-pipelines'
+alias c8='cursor /Users/raybunnage/Documents/github/dhg-mono-improve-google'
+alias c9='cursor /Users/raybunnage/Documents/github/dhg-mono-improve-suite'
+alias c0='cursor /Users/raybunnage/Documents/github/dhg-mono-integration-bug-fixes-tweaks'
+```
+
+Then use: `c1`, `c2`, etc. in terminal.
+
+## Recommended Keyboard Shortcuts
+
+### Option Keys (Alt):
+- ⌥1 → Development
+- ⌥2 → Admin Code
+- ⌥3 → Hub
+- ⌥4 → Docs
+- ⌥5 → Gmail
+- ⌥6 → Audio
+- ⌥7 → CLI Pipelines
+- ⌥8 → Google
+- ⌥9 → Suite
+- ⌥0 → Bug Fixes
+
+### Function Keys:
+- F1-F10 → Worktrees 1-10
+
+### Control + Option:
+- ⌃⌥1 through ⌃⌥0
+
+## Quick Test
+
+After setting up, you should be able to:
+1. Press ⌥1 to open Development worktree
+2. Press ⌥2 to open Admin Code worktree
+3. etc.
+
+Each will open in its own Cursor window with the correct color theme!

--- a/scripts/cli-pipeline/viewers/WORKTREE_SCRIPTS_README.md
+++ b/scripts/cli-pipeline/viewers/WORKTREE_SCRIPTS_README.md
@@ -1,0 +1,64 @@
+# Worktree Management Scripts
+
+## ⚠️ User-Specific Scripts - Update Paths!
+
+These scripts contain hardcoded paths specific to the original developer's machine. They're included as **templates** to help other macOS developers set up similar worktree management systems.
+
+### Before Using:
+
+1. **Update all paths** in the scripts to match your worktree locations
+2. **Update usernames** from `/Users/raybunnage/` to your username
+3. **Adjust worktree names** to match your setup
+
+### What's Included:
+
+#### 1. Worktree Switcher Server (`worktree-switcher-server.js`)
+- HTTP server on port 3010 for visual worktree switching
+- Auto-detects git worktrees
+- Works with any worktree setup (just update paths)
+
+#### 2. Peacock Color Setup (`setup-peacock-colors*.js`)
+- Assigns 10 distinct colors to VS Code/Cursor instances
+- Creates `.vscode/settings.json` in each worktree
+- Adds color emojis to window titles
+
+#### 3. Raycast Scripts (`raycast-scripts/`)
+- 10 script templates for keyboard shortcuts
+- Each opens a specific worktree in Cursor
+- Update paths in each `.sh` file before use
+
+#### 4. BetterTouchTool Config (`bettertouchtool-config.json`)
+- Pre-configured with ⌥1-⌥0 shortcuts
+- Update all script paths before importing
+
+#### 5. Shell Aliases Setup (`add-cursor-aliases.sh`)
+- Adds `c1`-`c0` aliases to your shell
+- Update paths in the script before running
+
+### Quick Path Update:
+
+```bash
+# Example: Update all scripts with your username
+find . -name "*.sh" -o -name "*.js" -o -name "*.json" | xargs sed -i '' 's/raybunnage/YOUR_USERNAME/g'
+
+# Update worktree paths to match your setup
+find . -name "*.sh" -o -name "*.js" -o -name "*.json" | xargs sed -i '' 's|/Users/[^/]*/Documents/github/|/YOUR/PATH/TO/WORKTREES/|g'
+```
+
+### Why These Are Committed:
+
+1. **Templates for other developers** - Shows the pattern for multi-worktree management
+2. **Documentation value** - Demonstrates the complete solution
+3. **Customization starting point** - Easier to modify than create from scratch
+
+### Setting Up Your Own:
+
+1. Clone these scripts
+2. Update all paths to match your worktrees
+3. Choose your preferred method:
+   - Raycast (recommended for ease)
+   - BetterTouchTool (for power users)
+   - Shell aliases (for terminal users)
+   - Native macOS shortcuts (no third-party tools)
+
+Each method provides keyboard shortcuts (⌥1-⌥0) to instantly switch between color-coded Cursor instances!

--- a/scripts/cli-pipeline/viewers/add-cursor-aliases.sh
+++ b/scripts/cli-pipeline/viewers/add-cursor-aliases.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Script to add Cursor aliases to your shell configuration
+
+SHELL_CONFIG="$HOME/.zshrc"
+
+# Backup current config
+cp "$SHELL_CONFIG" "$SHELL_CONFIG.backup.$(date +%Y%m%d_%H%M%S)"
+
+# Add aliases
+cat >> "$SHELL_CONFIG" << 'EOF'
+
+# Cursor Worktree Aliases - Added by worktree setup
+alias c1='cursor /Users/raybunnage/Documents/github/dhg-mono'
+alias c2='cursor /Users/raybunnage/Documents/github/dhg-mono-admin-code'
+alias c3='cursor /Users/raybunnage/Documents/github/dhg-mono-dhg-hub'
+alias c4='cursor /Users/raybunnage/Documents/github/dhg-mono-feature/dhg-mono-docs'
+alias c5='cursor /Users/raybunnage/Documents/github/dhg-mono-gmail-cli-pipeline-research-app'
+alias c6='cursor /Users/raybunnage/Documents/github/dhg-mono-improve-audio'
+alias c7='cursor /Users/raybunnage/Documents/github/dhg-mono-improve-cli-pipelines'
+alias c8='cursor /Users/raybunnage/Documents/github/dhg-mono-improve-google'
+alias c9='cursor /Users/raybunnage/Documents/github/dhg-mono-improve-suite'
+alias c0='cursor /Users/raybunnage/Documents/github/dhg-mono-integration-bug-fixes-tweaks'
+
+# Descriptive aliases
+alias cdev='c1'      # Development
+alias cadmin='c2'    # Admin Code
+alias chub='c3'      # Hub
+alias cdocs='c4'     # Docs
+alias cgmail='c5'    # Gmail
+alias caudio='c6'    # Audio
+alias ccli='c7'      # CLI Pipelines
+alias cgoogle='c8'   # Google
+alias csuite='c9'    # Suite
+alias cfix='c0'      # Bug Fixes
+
+# List all cursor aliases
+alias clist='echo "Cursor Worktree Aliases:
+c1/cdev    → 🟢 Development
+c2/cadmin  → 🔵 Admin Code
+c3/chub    → 🟣 Hub
+c4/cdocs   → 🟠 Docs
+c5/cgmail  → 🔴 Gmail
+c6/caudio  → 🟡 Audio
+c7/ccli    → 🔷 CLI Pipelines
+c8/cgoogle → 🩷 Google
+c9/csuite  → 🟩 Suite
+c0/cfix    → 🟪 Bug Fixes"'
+EOF
+
+echo "✅ Added Cursor aliases to $SHELL_CONFIG"
+echo ""
+echo "To activate the aliases, run:"
+echo "  source ~/.zshrc"
+echo ""
+echo "Then you can use:"
+echo "  c1  → Open Development"
+echo "  c2  → Open Admin Code"
+echo "  ... etc ..."
+echo ""
+echo "Or use descriptive names:"
+echo "  cdev → Development"
+echo "  cadmin → Admin Code"
+echo "  ... etc ..."
+echo ""
+echo "Type 'clist' to see all aliases"

--- a/scripts/cli-pipeline/viewers/bettertouchtool-config.json
+++ b/scripts/cli-pipeline/viewers/bettertouchtool-config.json
@@ -1,0 +1,91 @@
+{
+  "BTTPresetName": "Cursor Worktrees",
+  "BTTPresetContent": [
+    {
+      "BTTAppBundleIdentifier": "BT.G",
+      "BTTAppName": "Global",
+      "BTTTriggers": [
+        {
+          "BTTTriggerName": "Open Development (⌥1)",
+          "BTTTriggerType": 0,
+          "BTTShortcutKeyCode": 18,
+          "BTTShortcutModifierKeys": 524288,
+          "BTTActionType": 195,
+          "BTTShellTaskActionScript": "/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono"
+        },
+        {
+          "BTTTriggerName": "Open Admin Code (⌥2)",
+          "BTTTriggerType": 0,
+          "BTTShortcutKeyCode": 19,
+          "BTTShortcutModifierKeys": 524288,
+          "BTTActionType": 195,
+          "BTTShellTaskActionScript": "/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-admin-code"
+        },
+        {
+          "BTTTriggerName": "Open Hub (⌥3)",
+          "BTTTriggerType": 0,
+          "BTTShortcutKeyCode": 20,
+          "BTTShortcutModifierKeys": 524288,
+          "BTTActionType": 195,
+          "BTTShellTaskActionScript": "/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-dhg-hub"
+        },
+        {
+          "BTTTriggerName": "Open Docs (⌥4)",
+          "BTTTriggerType": 0,
+          "BTTShortcutKeyCode": 21,
+          "BTTShortcutModifierKeys": 524288,
+          "BTTActionType": 195,
+          "BTTShellTaskActionScript": "/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-feature/dhg-mono-docs"
+        },
+        {
+          "BTTTriggerName": "Open Gmail (⌥5)",
+          "BTTTriggerType": 0,
+          "BTTShortcutKeyCode": 23,
+          "BTTShortcutModifierKeys": 524288,
+          "BTTActionType": 195,
+          "BTTShellTaskActionScript": "/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-gmail-cli-pipeline-research-app"
+        },
+        {
+          "BTTTriggerName": "Open Audio (⌥6)",
+          "BTTTriggerType": 0,
+          "BTTShortcutKeyCode": 22,
+          "BTTShortcutModifierKeys": 524288,
+          "BTTActionType": 195,
+          "BTTShellTaskActionScript": "/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-improve-audio"
+        },
+        {
+          "BTTTriggerName": "Open CLI (⌥7)",
+          "BTTTriggerType": 0,
+          "BTTShortcutKeyCode": 26,
+          "BTTShortcutModifierKeys": 524288,
+          "BTTActionType": 195,
+          "BTTShellTaskActionScript": "/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-improve-cli-pipelines"
+        },
+        {
+          "BTTTriggerName": "Open Google (⌥8)",
+          "BTTTriggerType": 0,
+          "BTTShortcutKeyCode": 28,
+          "BTTShortcutModifierKeys": 524288,
+          "BTTActionType": 195,
+          "BTTShellTaskActionScript": "/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-improve-google"
+        },
+        {
+          "BTTTriggerName": "Open Suite (⌥9)",
+          "BTTTriggerType": 0,
+          "BTTShortcutKeyCode": 25,
+          "BTTShortcutModifierKeys": 524288,
+          "BTTActionType": 195,
+          "BTTShellTaskActionScript": "/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-improve-suite"
+        },
+        {
+          "BTTTriggerName": "Open Fixes (⌥0)",
+          "BTTTriggerType": 0,
+          "BTTShortcutKeyCode": 29,
+          "BTTShortcutModifierKeys": 524288,
+          "BTTActionType": 195,
+          "BTTShellTaskActionScript": "/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-integration-bug-fixes-tweaks"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/cli-pipeline/viewers/create-cursor-launcher-app.sh
+++ b/scripts/cli-pipeline/viewers/create-cursor-launcher-app.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Create a simple macOS app that provides keyboard shortcuts for Cursor worktrees
+# This works without Raycast or any third-party tools
+
+echo "Creating Cursor Launcher App with Keyboard Shortcuts"
+echo "==================================================="
+echo ""
+
+# Create the app
+APP_NAME="CursorWorktreeLauncher"
+APP_PATH="$HOME/Applications/$APP_NAME.app"
+
+mkdir -p "$APP_PATH/Contents/MacOS"
+mkdir -p "$APP_PATH/Contents/Resources"
+
+# Create the main launcher script
+cat > "$APP_PATH/Contents/MacOS/$APP_NAME" << 'EOF'
+#!/bin/bash
+
+# Cursor Worktree Launcher
+# Provides a quick picker for opening worktrees
+
+WORKTREES=(
+    "1. 🟢 Development|/Users/raybunnage/Documents/github/dhg-mono"
+    "2. 🔵 Admin Code|/Users/raybunnage/Documents/github/dhg-mono-admin-code"
+    "3. 🟣 Hub|/Users/raybunnage/Documents/github/dhg-mono-dhg-hub"
+    "4. 🟠 Docs|/Users/raybunnage/Documents/github/dhg-mono-feature/dhg-mono-docs"
+    "5. 🔴 Gmail|/Users/raybunnage/Documents/github/dhg-mono-gmail-cli-pipeline-research-app"
+    "6. 🟡 Audio|/Users/raybunnage/Documents/github/dhg-mono-improve-audio"
+    "7. 🔷 CLI Pipelines|/Users/raybunnage/Documents/github/dhg-mono-improve-cli-pipelines"
+    "8. 🩷 Google|/Users/raybunnage/Documents/github/dhg-mono-improve-google"
+    "9. 🟩 Suite|/Users/raybunnage/Documents/github/dhg-mono-improve-suite"
+    "0. 🟪 Bug Fixes|/Users/raybunnage/Documents/github/dhg-mono-integration-bug-fixes-tweaks"
+)
+
+# Create menu items
+MENU_ITEMS=""
+for item in "${WORKTREES[@]}"; do
+    NAME="${item%%|*}"
+    MENU_ITEMS="$MENU_ITEMS\"$NAME\", "
+done
+MENU_ITEMS=${MENU_ITEMS%, }
+
+# Use AppleScript to create a picker dialog
+CHOICE=$(osascript << END
+tell application "System Events"
+    activate
+    set worktreeList to {$MENU_ITEMS}
+    set selectedWorktree to choose from list worktreeList with prompt "Select a Cursor worktree to open:" with title "Cursor Worktree Launcher"
+    if selectedWorktree is false then
+        return ""
+    else
+        return item 1 of selectedWorktree
+    end if
+end tell
+END
+)
+
+# If user made a choice, open the corresponding worktree
+if [ -n "$CHOICE" ]; then
+    for item in "${WORKTREES[@]}"; do
+        NAME="${item%%|*}"
+        PATH="${item##*|}"
+        if [[ "$NAME" == "$CHOICE" ]]; then
+            /Applications/Cursor.app/Contents/MacOS/Cursor "$PATH"
+            break
+        fi
+    done
+fi
+EOF
+
+chmod +x "$APP_PATH/Contents/MacOS/$APP_NAME"
+
+# Create Info.plist
+cat > "$APP_PATH/Contents/Info.plist" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>$APP_NAME</string>
+    <key>CFBundleName</key>
+    <string>$APP_NAME</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.cursor.worktree.launcher</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>LSUIElement</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
+echo "✅ Created $APP_NAME app at: $APP_PATH"
+echo ""
+echo "To set up a GLOBAL keyboard shortcut:"
+echo ""
+echo "1. Open System Settings > Keyboard > Keyboard Shortcuts > App Shortcuts"
+echo "2. Click + to add a new shortcut"
+echo "3. Application: Choose '$APP_NAME' from your Applications folder"
+echo "4. Menu Title: Leave blank"
+echo "5. Keyboard Shortcut: Choose something like ⌃⌥C (Control+Option+C)"
+echo ""
+echo "Then you can press ⌃⌥C from anywhere to get a picker!"
+echo ""
+echo "Opening the app now to test it..."
+open "$APP_PATH"

--- a/scripts/cli-pipeline/viewers/open-cursor-directly.sh
+++ b/scripts/cli-pipeline/viewers/open-cursor-directly.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Direct test script to open Cursor worktrees
+echo "Testing Cursor worktree opening..."
+
+case "$1" in
+    1) /Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono ;;
+    2) /Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-admin-code ;;
+    3) /Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-dhg-hub ;;
+    4) /Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-feature/dhg-mono-docs ;;
+    5) /Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-gmail-cli-pipeline-research-app ;;
+    6) /Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-improve-audio ;;
+    7) /Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-improve-cli-pipelines ;;
+    8) /Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-improve-google ;;
+    9) /Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-improve-suite ;;
+    0) /Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-integration-bug-fixes-tweaks ;;
+    *)
+        echo "Usage: $0 [1-9,0]"
+        echo "1 = Development, 2 = Admin Code, 3 = Hub, etc."
+        ;;
+esac

--- a/scripts/cli-pipeline/viewers/raycast-cursor-shortcuts.sh
+++ b/scripts/cli-pipeline/viewers/raycast-cursor-shortcuts.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Raycast script snippets for opening Cursor worktrees
+# Copy each of these as a new Raycast script command
+
+cat << 'EOF'
+# Raycast Scripts for Cursor Worktrees
+# 
+# To use with Raycast:
+# 1. Open Raycast Preferences
+# 2. Go to Extensions > Script Commands
+# 3. Click + to add a new script
+# 4. Copy one of the scripts below
+# 5. Assign a hotkey (e.g., ⌥1)
+
+# === Script 1: Open Development Worktree ===
+#!/bin/bash
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Cursor Development
+# @raycast.mode silent
+# @raycast.packageName Cursor Worktrees
+# @raycast.icon 🟢
+
+/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono
+
+# === Script 2: Open Admin Code Worktree ===
+#!/bin/bash
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Cursor Admin Code
+# @raycast.mode silent
+# @raycast.packageName Cursor Worktrees
+# @raycast.icon 🔵
+
+/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-admin-code
+
+# === Script 3: Open Hub Worktree ===
+#!/bin/bash
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Cursor Hub
+# @raycast.mode silent
+# @raycast.packageName Cursor Worktrees
+# @raycast.icon 🟣
+
+/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-dhg-hub
+
+# Continue this pattern for all 10 worktrees...
+EOF

--- a/scripts/cli-pipeline/viewers/raycast-scripts/.gitignore
+++ b/scripts/cli-pipeline/viewers/raycast-scripts/.gitignore
@@ -1,0 +1,7 @@
+# Raycast Script Metadata
+*.plist
+.DS_Store
+
+# These scripts are personalized with local paths
+# Uncomment the line below if you want to exclude them from git
+# *.sh

--- a/scripts/cli-pipeline/viewers/raycast-scripts/README.md
+++ b/scripts/cli-pipeline/viewers/raycast-scripts/README.md
@@ -1,0 +1,62 @@
+# Raycast Scripts for Cursor Worktrees
+
+## Setup Instructions
+
+### Method 1: Import All Scripts at Once
+1. Open Raycast
+2. Press `⌘,` to open preferences
+3. Go to Extensions → Script Commands
+4. Click the folder icon to open the scripts folder
+5. Copy all `.sh` files from this directory to Raycast's script folder
+6. Raycast will automatically detect and add them
+
+### Method 2: Add Scripts Individually
+1. Open Raycast preferences (`⌘,`)
+2. Go to Extensions → Script Commands
+3. Click `+` → Create Script Command
+4. Choose "Bash" as the template
+5. Copy the content from one of the scripts
+6. Save and assign a hotkey
+
+## Assigning Hotkeys
+
+After importing the scripts:
+
+1. In Raycast preferences, go to Extensions → Script Commands
+2. Find each script (they'll be named "Open Development", "Open Admin Code", etc.)
+3. Click on the script
+4. Click "Record Hotkey"
+5. Press your desired key combination:
+
+### Recommended Hotkeys:
+- ⌥1 → Open Development
+- ⌥2 → Open Admin Code
+- ⌥3 → Open Hub
+- ⌥4 → Open Docs
+- ⌥5 → Open Gmail
+- ⌥6 → Open Audio
+- ⌥7 → Open CLI Pipelines
+- ⌥8 → Open Google
+- ⌥9 → Open Suite
+- ⌥0 → Open Bug Fixes
+
+### Alternative Hotkeys:
+- F1-F10 (if you don't use function keys for other things)
+- ⌃⌥1 through ⌃⌥0 (Control+Option+Number)
+- ⌘⌥1 through ⌘⌥0 (Command+Option+Number)
+
+## Testing
+
+After setup, press your hotkey and the corresponding Cursor window should open immediately with the correct worktree and color theme!
+
+## Troubleshooting
+
+If a script doesn't work:
+1. Make sure Cursor is installed at `/Applications/Cursor.app`
+2. Check that the worktree paths are correct
+3. Ensure the scripts have execute permissions: `chmod +x *.sh`
+4. Try running a script manually in Terminal to see any errors
+
+## Customization
+
+Each script includes an emoji icon that matches the Peacock color for that worktree. You can change these by editing the `@raycast.icon` line in each script.

--- a/scripts/cli-pipeline/viewers/raycast-scripts/cursor-1-development.sh
+++ b/scripts/cli-pipeline/viewers/raycast-scripts/cursor-1-development.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Development
+# @raycast.mode silent
+# @raycast.packageName Cursor Worktrees
+# @raycast.icon 🟢
+# @raycast.iconDark 🟢
+
+/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono

--- a/scripts/cli-pipeline/viewers/raycast-scripts/cursor-10-fixes.sh
+++ b/scripts/cli-pipeline/viewers/raycast-scripts/cursor-10-fixes.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Bug Fixes
+# @raycast.mode silent
+# @raycast.packageName Cursor Worktrees
+# @raycast.icon 🟪
+# @raycast.iconDark 🟪
+
+/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-integration-bug-fixes-tweaks

--- a/scripts/cli-pipeline/viewers/raycast-scripts/cursor-2-admin-code.sh
+++ b/scripts/cli-pipeline/viewers/raycast-scripts/cursor-2-admin-code.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Admin Code
+# @raycast.mode silent
+# @raycast.packageName Cursor Worktrees
+# @raycast.icon 🔵
+# @raycast.iconDark 🔵
+
+/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-admin-code

--- a/scripts/cli-pipeline/viewers/raycast-scripts/cursor-3-hub.sh
+++ b/scripts/cli-pipeline/viewers/raycast-scripts/cursor-3-hub.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Hub
+# @raycast.mode silent
+# @raycast.packageName Cursor Worktrees
+# @raycast.icon 🟣
+# @raycast.iconDark 🟣
+
+/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-dhg-hub

--- a/scripts/cli-pipeline/viewers/raycast-scripts/cursor-4-docs.sh
+++ b/scripts/cli-pipeline/viewers/raycast-scripts/cursor-4-docs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Docs
+# @raycast.mode silent
+# @raycast.packageName Cursor Worktrees
+# @raycast.icon 🟠
+# @raycast.iconDark 🟠
+
+/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-feature/dhg-mono-docs

--- a/scripts/cli-pipeline/viewers/raycast-scripts/cursor-5-gmail.sh
+++ b/scripts/cli-pipeline/viewers/raycast-scripts/cursor-5-gmail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Gmail
+# @raycast.mode silent
+# @raycast.packageName Cursor Worktrees
+# @raycast.icon 🔴
+# @raycast.iconDark 🔴
+
+/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-gmail-cli-pipeline-research-app

--- a/scripts/cli-pipeline/viewers/raycast-scripts/cursor-6-audio.sh
+++ b/scripts/cli-pipeline/viewers/raycast-scripts/cursor-6-audio.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Audio
+# @raycast.mode silent
+# @raycast.packageName Cursor Worktrees
+# @raycast.icon 🟡
+# @raycast.iconDark 🟡
+
+/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-improve-audio

--- a/scripts/cli-pipeline/viewers/raycast-scripts/cursor-7-cli.sh
+++ b/scripts/cli-pipeline/viewers/raycast-scripts/cursor-7-cli.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open CLI Pipelines
+# @raycast.mode silent
+# @raycast.packageName Cursor Worktrees
+# @raycast.icon 🔷
+# @raycast.iconDark 🔷
+
+/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-improve-cli-pipelines

--- a/scripts/cli-pipeline/viewers/raycast-scripts/cursor-8-google.sh
+++ b/scripts/cli-pipeline/viewers/raycast-scripts/cursor-8-google.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Google
+# @raycast.mode silent
+# @raycast.packageName Cursor Worktrees
+# @raycast.icon 🩷
+# @raycast.iconDark 🩷
+
+/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-improve-google

--- a/scripts/cli-pipeline/viewers/raycast-scripts/cursor-9-suite.sh
+++ b/scripts/cli-pipeline/viewers/raycast-scripts/cursor-9-suite.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Open Suite
+# @raycast.mode silent
+# @raycast.packageName Cursor Worktrees
+# @raycast.icon 🟩
+# @raycast.iconDark 🟩
+
+/Applications/Cursor.app/Contents/MacOS/Cursor /Users/raybunnage/Documents/github/dhg-mono-improve-suite

--- a/scripts/cli-pipeline/viewers/setup-raycast-scripts.sh
+++ b/scripts/cli-pipeline/viewers/setup-raycast-scripts.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+echo "Setting up Raycast Scripts for Cursor Worktrees"
+echo "=============================================="
+echo ""
+
+# Check if Raycast is running
+if pgrep -x "Raycast" > /dev/null; then
+    echo "✅ Raycast is running"
+else
+    echo "❌ Raycast is not running. Please start Raycast first."
+    echo "   Open Raycast with: Cmd+Space (or your custom hotkey)"
+    exit 1
+fi
+
+echo ""
+echo "SETUP INSTRUCTIONS:"
+echo ""
+echo "1. Open Raycast (Cmd+Space)"
+echo "2. Type: 'Extensions' and press Enter"
+echo "3. Find 'Script Commands' in the list"
+echo "4. Click 'Open Scripts Folder' button (folder icon)"
+echo ""
+echo "This will create and open the Script Commands folder."
+echo ""
+echo "Press Enter when you've done this..."
+read
+
+# Now check if the folder exists
+SCRIPT_DIR="$HOME/Library/Application Support/Script Commands"
+if [ -d "$SCRIPT_DIR" ]; then
+    echo "✅ Found Script Commands folder!"
+    echo ""
+    echo "Copying scripts..."
+    
+    # Copy all the scripts
+    cp scripts/cli-pipeline/viewers/raycast-scripts/*.sh "$SCRIPT_DIR/"
+    
+    echo "✅ Copied all scripts!"
+    echo ""
+    echo "NEXT STEPS:"
+    echo "1. Go back to Raycast Extensions"
+    echo "2. You should now see all 10 scripts listed"
+    echo "3. Click on each one and assign hotkeys:"
+    echo "   - Click the script"
+    echo "   - Click 'Record Hotkey'"
+    echo "   - Press Option+1 (⌥1) for the first one, etc."
+    echo ""
+    echo "Recommended hotkeys:"
+    echo "  ⌥1 → 🟢 Open Development"
+    echo "  ⌥2 → 🔵 Open Admin Code"
+    echo "  ⌥3 → 🟣 Open Hub"
+    echo "  ⌥4 → 🟠 Open Docs"
+    echo "  ⌥5 → 🔴 Open Gmail"
+    echo "  ⌥6 → 🟡 Open Audio"
+    echo "  ⌥7 → 🔷 Open CLI Pipelines"
+    echo "  ⌥8 → 🩷 Open Google"
+    echo "  ⌥9 → 🟩 Open Suite"
+    echo "  ⌥0 → 🟪 Open Bug Fixes"
+else
+    echo "❌ Script Commands folder still not found."
+    echo ""
+    echo "Alternative method:"
+    echo "1. In Raycast, search for 'Create Script Command'"
+    echo "2. This will open the script creation flow"
+    echo "3. Cancel it, but it will create the folder"
+    echo "4. Run this script again"
+fi

--- a/scripts/cli-pipeline/viewers/setup-worktree-shortcuts.sh
+++ b/scripts/cli-pipeline/viewers/setup-worktree-shortcuts.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Script to create macOS Automator apps for each worktree
+# These can then be assigned keyboard shortcuts in System Preferences
+
+WORKTREES=(
+    "/Users/raybunnage/Documents/github/dhg-mono"
+    "/Users/raybunnage/Documents/github/dhg-mono-admin-code"
+    "/Users/raybunnage/Documents/github/dhg-mono-dhg-hub"
+    "/Users/raybunnage/Documents/github/dhg-mono-feature/dhg-mono-docs"
+    "/Users/raybunnage/Documents/github/dhg-mono-gmail-cli-pipeline-research-app"
+    "/Users/raybunnage/Documents/github/dhg-mono-improve-audio"
+    "/Users/raybunnage/Documents/github/dhg-mono-improve-cli-pipelines"
+    "/Users/raybunnage/Documents/github/dhg-mono-improve-google"
+    "/Users/raybunnage/Documents/github/dhg-mono-improve-suite"
+    "/Users/raybunnage/Documents/github/dhg-mono-integration-bug-fixes-tweaks"
+)
+
+NAMES=(
+    "Cursor-1-Development"
+    "Cursor-2-AdminCode"
+    "Cursor-3-Hub"
+    "Cursor-4-Docs"
+    "Cursor-5-Gmail"
+    "Cursor-6-Audio"
+    "Cursor-7-CLI"
+    "Cursor-8-Google"
+    "Cursor-9-Suite"
+    "Cursor-10-Fixes"
+)
+
+echo "Creating Automator apps for Cursor worktrees..."
+echo ""
+echo "After running this script, you'll need to:"
+echo "1. Go to System Settings > Keyboard > Keyboard Shortcuts > App Shortcuts"
+echo "2. Click + to add a new shortcut"
+echo "3. Select 'All Applications'"
+echo "4. Enter the exact app name (e.g., 'Cursor-1-Development')"
+echo "5. Assign your shortcut (e.g., ⌥1 for Option+1 or ⌃⌥1 for Ctrl+Option+1)"
+echo ""
+echo "Creating apps..."
+
+APPS_DIR="$HOME/Applications/CursorWorktrees"
+mkdir -p "$APPS_DIR"
+
+for i in "${!WORKTREES[@]}"; do
+    WORKTREE="${WORKTREES[$i]}"
+    APP_NAME="${NAMES[$i]}"
+    APP_PATH="$APPS_DIR/$APP_NAME.app"
+    
+    echo "Creating $APP_NAME..."
+    
+    # Create the app bundle structure
+    mkdir -p "$APP_PATH/Contents/MacOS"
+    
+    # Create the executable script
+    cat > "$APP_PATH/Contents/MacOS/$APP_NAME" << EOF
+#!/bin/bash
+# Open Cursor in specific worktree
+/Applications/Cursor.app/Contents/MacOS/Cursor "$WORKTREE"
+EOF
+    
+    # Make it executable
+    chmod +x "$APP_PATH/Contents/MacOS/$APP_NAME"
+    
+    # Create Info.plist
+    cat > "$APP_PATH/Contents/Info.plist" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>$APP_NAME</string>
+    <key>CFBundleName</key>
+    <string>$APP_NAME</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.cursor.worktree.$i</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+</dict>
+</plist>
+EOF
+done
+
+echo ""
+echo "✅ Created $i apps in: $APPS_DIR"
+echo ""
+echo "Next steps:"
+echo "1. Open System Settings > Keyboard > Keyboard Shortcuts > App Shortcuts"
+echo "2. Add shortcuts for each app"
+echo ""
+echo "Recommended shortcuts:"
+echo "  ⌥1 (Option+1) → Cursor-1-Development"
+echo "  ⌥2 (Option+2) → Cursor-2-AdminCode"
+echo "  ⌥3 (Option+3) → Cursor-3-Hub"
+echo "  ⌥4 (Option+4) → Cursor-4-Docs"
+echo "  ⌥5 (Option+5) → Cursor-5-Gmail"
+echo "  ⌥6 (Option+6) → Cursor-6-Audio"
+echo "  ⌥7 (Option+7) → Cursor-7-CLI"
+echo "  ⌥8 (Option+8) → Cursor-8-Google"
+echo "  ⌥9 (Option+9) → Cursor-9-Suite"
+echo "  ⌥0 (Option+0) → Cursor-10-Fixes"
+echo ""
+echo "Or use F-keys: F1-F10"
+echo "Or use Ctrl+Option: ⌃⌥1 through ⌃⌥0"


### PR DESCRIPTION
## Summary
- Add setup-raycast-scripts.sh for interactive Raycast setup
- Add open-cursor-directly.sh for testing Cursor launcher
- Add create-cursor-launcher-app.sh for native macOS app creation
- Additional worktree launcher helper scripts for improved developer workflow

## Changes
- **setup-raycast-scripts.sh**: Interactive script to help users set up Raycast scripts quickly
- **open-cursor-directly.sh**: Direct Cursor launch script for testing purposes
- **create-cursor-launcher-app.sh**: Creates a native macOS launcher app for Cursor

These scripts enhance the worktree switching workflow by providing multiple ways to launch Cursor with different worktrees.

🤖 Generated with [Claude Code](https://claude.ai/code)